### PR TITLE
Add Create Quotation flow

### DIFF
--- a/Quotation_Create_v1.gs
+++ b/Quotation_Create_v1.gs
@@ -1,0 +1,531 @@
+/**
+ * Create Quotation flow — dialog + document writer
+ */
+
+const QC_MASTER_TAB_NAME = '00_Master Appointments';
+
+const QC_SO_ALIASES = ['SO#', 'SO', 'SO Number'];
+const QC_CUSTOMER_NAME_ALIASES = ['Customer Name', 'Customer', 'Client Name'];
+const QC_EMAIL_ALIASES = ['EmailLower', 'Email'];
+const QC_PHONE_ALIASES = ['PhoneNorm', 'Phone'];
+const QC_BRAND_ALIASES = ['Brand', 'Company'];
+const QC_ROOT_APPT_ALIASES = ['RootApptID', 'Root Appt ID', 'Root Appointment ID', 'Appt ID', 'ApptID'];
+const QC_PRODUCT_DESC_ALIASES = ['Product Description', 'Product', 'Product Name', 'Setting Description', 'Design Request', '3D Design Request'];
+const QC_PRODUCT_DETAILS_ALIASES = ['Product Details', 'Design Notes', 'Ring Style', 'Metal', 'US Size', 'Center Type', 'Diamond Dimension'];
+const QC_QUANTITY_ALIASES = ['Quantity', 'Qty'];
+const QC_TRACKER_ALIASES = ['Customer Order Tracker URL', 'Order Tracker URL', 'Tracker URL'];
+const QC_QUOTATION_URL_ALIASES = ['Quotation URL'];
+
+const QC_MONEY_HEADERS = ['V1 Quotation', 'V2 Quotation', 'Approved Price'];
+
+function qc_openCreateQuotation() {
+  const html = HtmlService.createHtmlOutputFromFile('dlg_create_quotation_v1')
+    .setWidth(1100)
+    .setHeight(760);
+  SpreadsheetApp.getUi().showModalDialog(html, 'Create Quotation');
+}
+
+function qc_init() {
+  const t = ADM_time && ADM_time('qc_init');
+  try {
+    const ss = SpreadsheetApp.getActive();
+    const master = ss.getSheetByName(QC_MASTER_TAB_NAME);
+    if (!master) {
+      throw new Error('Sheet "' + QC_MASTER_TAB_NAME + '" not found.');
+    }
+    const activeSheet = ss.getActiveSheet();
+    if (!activeSheet || activeSheet.getSheetId() !== master.getSheetId()) {
+      throw new Error('Please activate the "' + QC_MASTER_TAB_NAME + '" sheet and select a data row.');
+    }
+    const rng = activeSheet.getActiveRange();
+    if (!rng) throw new Error('Select a row first.');
+    const rowIndex = rng.getRow();
+    if (rowIndex <= 1) throw new Error('Select a data row (below the header).');
+
+    const lastCol = master.getLastColumn();
+    const headerRow = master.getRange(1, 1, 1, lastCol).getDisplayValues()[0].map(s => String(s || '').trim());
+    const H = hIndex_(headerRow);
+
+    const rowRange = master.getRange(rowIndex, 1, 1, lastCol);
+    const rowValues = rowRange.getValues()[0];
+    const rowDisplay = rowRange.getDisplayValues()[0];
+    const rowRich = rowRange.getRichTextValues()[0];
+
+    const ctx = qc_buildContext_(ss, master, H, rowIndex, rowDisplay, rowValues);
+    const product = qc_buildProductSnapshot_(H, rowDisplay, rowValues, ctx.trackerUrl);
+    const money = qc_buildMoneyPrefill_(H, rowDisplay, rowValues);
+    const links = qc_buildLinks_(H, rowDisplay, rowRich);
+    const known = qc_collectKnownSOs_(master, H, ctx.emailLower, ctx.phoneNorm);
+
+    const payload = {
+      context: {
+        rowIndex,
+        sheetId: master.getSheetId(),
+        masterUrl: ss.getUrl(),
+        brand: ctx.brand,
+        RootApptID: ctx.RootApptID,
+        SO: ctx.SO,
+        customerName: ctx.customerName,
+        emailLower: ctx.emailLower,
+        phoneNorm: ctx.phoneNorm
+      },
+      productSnapshot: product,
+      knownSOs: known,
+      money,
+      links,
+      ui: {
+        currencyHint: '$1,234.00',
+        knownSoCount: known.length
+      }
+    };
+
+    ADM_dbg && ADM_dbg('qc_init payload', payload);
+    return payload;
+  } finally {
+    try { t && t(); } catch (ignored) {}
+  }
+}
+
+function qc_submit(payload) {
+  const timer = ADM_time && ADM_time('qc_submit');
+  try {
+    if (!payload || typeof payload !== 'object') throw new Error('Missing payload.');
+    const ctx = payload.context || {};
+    const rowIndex = Number(ctx.rowIndex || payload.rowIndex || 0);
+    if (!rowIndex) throw new Error('Row index missing.');
+
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    if (!items.length) throw new Error('Add at least one line item.');
+
+    const cleanItems = [];
+    const selectedSOs = [];
+    items.forEach((item, idx) => {
+      const qty = Math.max(1, Math.floor(Number(item.qty || item.quantity || 0)));
+      if (!qty || !isFinite(qty)) throw new Error('Line ' + (idx + 1) + ' has an invalid quantity.');
+      const so = String(item.so || '').trim();
+      if (so) selectedSOs.push(so);
+      cleanItems.push({
+        so,
+        productDescription: String(item.productDescription || '').trim(),
+        productDetails: String(item.productDetails || '').trim(),
+        qty
+      });
+    });
+
+    const pricing = payload.pricing || {};
+    const v1 = qc_parseMoney_(pricing.v1);
+    if (v1 === '' || v1 < 0) throw new Error('“V1 Quotation” must be a number greater than or equal to 0.');
+    const v2 = qc_parseMoney_(pricing.v2);
+    const approved = qc_parseMoney_(pricing.approved);
+
+    const ss = SpreadsheetApp.getActive();
+    const master = ss.getSheetByName(QC_MASTER_TAB_NAME);
+    if (!master) throw new Error('Sheet "' + QC_MASTER_TAB_NAME + '" not found.');
+    const lastCol = master.getLastColumn();
+    const headerRow = master.getRange(1, 1, 1, lastCol).getDisplayValues()[0].map(s => String(s || '').trim());
+    const H = hIndex_(headerRow);
+
+    const now = new Date();
+    const tz = Session.getScriptTimeZone() || 'America/Los_Angeles';
+    const todayIso = Utilities.formatDate(now, tz, 'yyyy-MM-dd');
+    const todayPretty = Utilities.formatDate(now, tz, 'MMMM d, yyyy');
+
+    let docUrl = '';
+    if (!payload.saveOnly) {
+      const templateId = quotationTemplateIdForBrand_(ctx.brand);
+      if (!templateId) throw new Error('No quotation template configured for brand "' + (ctx.brand || 'Unknown') + '".');
+
+      const existingLink = qc_extractLinkFromSheet_(master, H, rowIndex);
+      const filename = qc_buildQuotationFilename_(ctx.brand, selectedSOs, ctx.RootApptID);
+      const placeholders = {
+        BRAND: ctx.brand || '',
+        CUSTOMER_NAME: ctx.customerName || '',
+        CUSTOMER_EMAIL: ctx.emailLower || '',
+        CUSTOMER_PHONE: ctx.phoneNorm || '',
+        ROOT_APPT_ID: ctx.RootApptID || '',
+        SELECTED_SOS: selectedSOs.join(', '),
+        DATE_TODAY: todayPretty,
+        V1_QUOTATION: money_(v1),
+        V2_QUOTATION: v2 === '' ? '' : money_(v2),
+        APPROVED_PRICE: approved === '' ? '' : money_(approved)
+      };
+
+      const doc = ensureAndFillQuotationForRow_({
+        rowIndex,
+        templateId,
+        filename,
+        placeholders,
+        items: cleanItems,
+        existingUrl: existingLink && existingLink.url
+      });
+      docUrl = doc && doc.url ? doc.url : '';
+    }
+
+    const updates = {
+      'V1 Quotation': v1,
+      'V2 Quotation': v2 === '' ? '' : v2,
+      'Approved Price': approved === '' ? '' : approved
+    };
+    if (docUrl) {
+      updates['Quotation URL'] = docUrl;
+      updates['Quotation Date'] = todayIso;
+    }
+
+    qc_writeBack_(master, H, rowIndex, updates);
+
+    const result = { ok: true, url: docUrl, rowIndex };
+    ADM_dbg && ADM_dbg('qc_submit result', result);
+    return result;
+  } catch (err) {
+    ADM_dbg && ADM_dbg('qc_submit error', String(err && err.stack || err));
+    throw err;
+  } finally {
+    try { timer && timer(); } catch (ignored) {}
+  }
+}
+
+function qc_buildContext_(ss, sheet, H, rowIndex, rowDisplay, rowValues) {
+  const get = (aliases) => qc_pickFirst_(H, aliases, rowDisplay, rowValues);
+  const brand = get(QC_BRAND_ALIASES);
+  const so = get(QC_SO_ALIASES);
+  const customerName = get(QC_CUSTOMER_NAME_ALIASES);
+  const emailLower = (get(QC_EMAIL_ALIASES) || '').toLowerCase();
+  const phoneNorm = qc_normPhone_(get(QC_PHONE_ALIASES));
+  const rootApptId = get(QC_ROOT_APPT_ALIASES);
+  const trackerUrl = get(QC_TRACKER_ALIASES);
+
+  return {
+    sheetId: sheet.getSheetId(),
+    rowIndex,
+    brand,
+    SO: so,
+    customerName,
+    emailLower,
+    phoneNorm,
+    RootApptID: rootApptId,
+    trackerUrl
+  };
+}
+
+function qc_buildProductSnapshot_(H, rowDisplay, rowValues, trackerUrl) {
+  const get = (aliases) => qc_pickFirst_(H, aliases, rowDisplay, rowValues);
+  let productDescription = get(QC_PRODUCT_DESC_ALIASES);
+  let productDetails = get(QC_PRODUCT_DETAILS_ALIASES);
+  let quantityRaw = get(QC_QUANTITY_ALIASES);
+  let quantity = Math.max(1, Math.round(num_(quantityRaw || 1, 1)) || 1);
+
+  if (!productDescription || !productDetails) {
+    const fallback = qc_fetchProductSnapshotFromTracker_(trackerUrl);
+    if (fallback) {
+      if (!productDescription && fallback.productDescription) productDescription = fallback.productDescription;
+      if (!productDetails && fallback.productDetails) productDetails = fallback.productDetails;
+      if ((!quantity || quantity === 1) && fallback.quantity) quantity = fallback.quantity;
+    }
+  }
+
+  return {
+    so: get(QC_SO_ALIASES),
+    productDescription: productDescription || '',
+    productDetails: productDetails || '',
+    quantity
+  };
+}
+
+function qc_buildMoneyPrefill_(H, rowDisplay, rowValues) {
+  const out = {};
+  QC_MONEY_HEADERS.forEach(label => {
+    const col = pickH_(H, [label]);
+    const raw = col ? rowValues[col - 1] : '';
+    const display = col ? rowDisplay[col - 1] : '';
+    const num = qc_parseMoney_(raw);
+    out[label] = {
+      number: num === '' ? '' : num,
+      display: display || (num === '' ? '' : money_(num))
+    };
+  });
+  return out;
+}
+
+function qc_buildLinks_(H, rowDisplay, rowRich) {
+  const res = {};
+  const col = pickH_(H, QC_QUOTATION_URL_ALIASES);
+  if (col) {
+    res.quotationUrl = qc_extractLink_(rowRich[col - 1], rowDisplay[col - 1]);
+  }
+  return res;
+}
+
+function qc_collectKnownSOs_(sheet, H, emailLower, phoneNorm) {
+  const lr = sheet.getLastRow();
+  if (lr <= 1) return [];
+  const lc = sheet.getLastColumn();
+  const range = sheet.getRange(2, 1, lr - 1, lc);
+  const vals = range.getValues();
+  const display = range.getDisplayValues();
+  const emailCol = pickH_(H, QC_EMAIL_ALIASES);
+  const phoneCol = pickH_(H, QC_PHONE_ALIASES);
+  const brandCol = pickH_(H, QC_BRAND_ALIASES);
+  const soCol = pickH_(H, QC_SO_ALIASES);
+
+  const seen = new Set();
+  const list = [];
+  for (let i = 0; i < vals.length; i++) {
+    const rowVals = vals[i];
+    const rowDisp = display[i];
+    const email = emailCol ? String(rowVals[emailCol - 1] || rowDisp[emailCol - 1] || '').toLowerCase() : '';
+    const phone = phoneCol ? qc_normPhone_(rowVals[phoneCol - 1] || rowDisp[phoneCol - 1] || '') : '';
+    if (emailLower && email && emailLower === email) {
+      // pass
+    } else if (phoneNorm && phone && phoneNorm === phone) {
+      // pass
+    } else {
+      continue;
+    }
+    const so = soCol ? String(rowDisp[soCol - 1] || '').trim() : '';
+    if (!so) continue;
+    const brand = brandCol ? String(rowDisp[brandCol - 1] || '').trim() : '';
+    const key = (brand || '') + '|' + so;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const productDescription = qc_pickFirstRow_(H, QC_PRODUCT_DESC_ALIASES, rowDisp, rowVals);
+    const productDetails = qc_pickFirstRow_(H, QC_PRODUCT_DETAILS_ALIASES, rowDisp, rowVals);
+    const qtyRaw = qc_pickFirstRow_(H, QC_QUANTITY_ALIASES, rowDisp, rowVals);
+    const qty = Math.max(1, Math.round(num_(qtyRaw || 1, 1)) || 1);
+    list.push({
+      key,
+      brand,
+      so,
+      label: [brand, so].filter(Boolean).join(' • '),
+      productDescription: productDescription || '',
+      productDetails: productDetails || '',
+      quantity: qty
+    });
+  }
+  return list;
+}
+
+function qc_fetchProductSnapshotFromTracker_(trackerUrl) {
+  try {
+    if (!trackerUrl) return null;
+    const fileId = fileIdFromUrl_(trackerUrl);
+    if (!fileId) return null;
+    const ss = SpreadsheetApp.openById(fileId);
+    const sheet = ss.getSheets()[0];
+    if (!sheet) return null;
+    const lr = sheet.getLastRow();
+    const lc = sheet.getLastColumn();
+    if (lr < 2 || lc < 1) return null;
+    const hdr = sheet.getRange(1, 1, 1, lc).getDisplayValues()[0].map(s => String(s || '').trim());
+    const H = hIndex_(hdr);
+    const row = sheet.getRange(lr, 1, 1, lc).getDisplayValues()[0];
+    const get = (aliases) => {
+      for (let i = 0; i < aliases.length; i++) {
+        const col = pickH_(H, [aliases[i]]);
+        if (col) return row[col - 1];
+      }
+      return '';
+    };
+    const quantityRaw = get(QC_QUANTITY_ALIASES);
+    return {
+      productDescription: get(QC_PRODUCT_DESC_ALIASES) || '',
+      productDetails: get(QC_PRODUCT_DETAILS_ALIASES) || '',
+      quantity: Math.max(1, Math.round(num_(quantityRaw || 1, 1)) || 1)
+    };
+  } catch (err) {
+    ADM_dbg && ADM_dbg('qc_fetchProductSnapshotFromTracker_ error', String(err && err.stack || err));
+    return null;
+  }
+}
+
+function qc_extractLink_(rich, display) {
+  if (rich) {
+    const runs = rich.getRuns();
+    for (let i = 0; i < runs.length; i++) {
+      const run = runs[i];
+      const url = run.getLinkUrl();
+      if (url) {
+        return { text: run.getText(), url };
+      }
+    }
+    const url = rich.getLinkUrl && rich.getLinkUrl();
+    if (url) return { text: display || '', url };
+  }
+  const url = (display && /https?:\/\//i.test(display)) ? display : '';
+  return { text: display || '', url };
+}
+
+function qc_extractLinkFromSheet_(sheet, H, rowIndex) {
+  const col = pickH_(H, QC_QUOTATION_URL_ALIASES);
+  if (!col) return null;
+  const cell = sheet.getRange(rowIndex, col);
+  const rich = cell.getRichTextValue();
+  const display = cell.getDisplayValue();
+  return qc_extractLink_(rich, display);
+}
+
+function qc_writeBack_(sheet, H, rowIndex, updates) {
+  if (!updates) return;
+  let maxCol = sheet.getLastColumn();
+  Object.keys(updates).forEach(header => {
+    if (!header) return;
+    const col = pickH_(H, [header]);
+    if (!col) {
+      maxCol += 1;
+      sheet.getRange(1, maxCol).setValue(header);
+      H[header] = maxCol;
+    }
+  });
+  const lc = sheet.getLastColumn();
+  const rowRange = sheet.getRange(rowIndex, 1, 1, lc);
+  const rowValues = rowRange.getValues()[0];
+  Object.keys(updates).forEach(header => {
+    if (header === 'Quotation URL') return;
+    const col = pickH_(H, [header]);
+    if (col) rowValues[col - 1] = updates[header];
+  });
+  rowRange.setValues([rowValues]);
+
+  if (updates['Quotation URL']) {
+    const col = pickH_(H, ['Quotation URL']);
+    if (col) {
+      const cell = sheet.getRange(rowIndex, col);
+      const url = String(updates['Quotation URL']);
+      if (url) {
+        const rt = SpreadsheetApp.newRichTextValue().setText('Open').setLinkUrl(url).build();
+        cell.setRichTextValue(rt);
+      } else {
+        cell.clearContent();
+      }
+    }
+  }
+}
+
+function qc_normPhone_(phone) {
+  const digits = String(phone || '').replace(/\D+/g, '');
+  return digits || '';
+}
+
+function qc_pickFirst_(H, aliases, displayRow, valueRow) {
+  return qc_pickFirstRow_(H, aliases, displayRow, valueRow) || '';
+}
+
+function qc_pickFirstRow_(H, aliases, displayRow, valueRow) {
+  if (!aliases) return '';
+  for (let i = 0; i < aliases.length; i++) {
+    const col = pickH_(H, [aliases[i]]);
+    if (col) {
+      const val = valueRow[col - 1];
+      const display = displayRow[col - 1];
+      if (val != null && val !== '') return String(val);
+      if (display != null && display !== '') return String(display);
+    }
+  }
+  return '';
+}
+
+function quotationTemplateIdForBrand_(brand) {
+  const sp = PropertiesService.getScriptProperties();
+  const key = 'QUOTATION_TEMPLATE_ID_' + String(brand || '').trim().toUpperCase();
+  const fallbackKey = 'QUOTATION_TEMPLATE_ID_DEFAULT';
+  return (sp.getProperty(key) || sp.getProperty(fallbackKey) || '').trim();
+}
+
+function ensureAndFillQuotationForRow_(opts) {
+  if (!opts || !opts.templateId) throw new Error('Missing quotation template ID.');
+  const templateFile = DriveApp.getFileById(opts.templateId);
+  const filename = opts.filename || ('Quotation ' + new Date().toISOString());
+
+  let docFile;
+  if (opts.existingUrl) {
+    try {
+      const existingId = fileIdFromUrl_(opts.existingUrl);
+      if (existingId) docFile = DriveApp.getFileById(existingId);
+    } catch (err) {
+      ADM_dbg && ADM_dbg('ensureAndFillQuotationForRow_ existing file error', String(err));
+    }
+  }
+  if (!docFile) {
+    docFile = templateFile.makeCopy(filename);
+  } else {
+    docFile.setName(filename);
+  }
+
+  const doc = DocumentApp.openById(docFile.getId());
+  const body = doc.getBody();
+  const placeholders = opts.placeholders || {};
+  Object.keys(placeholders).forEach(key => {
+    const needle = '{{' + key + '}}';
+    body.replaceText(qc_escapeForRegex_(needle), String(placeholders[key] == null ? '' : placeholders[key]));
+  });
+
+  if (Array.isArray(opts.items) && opts.items.length) {
+    const tableHeader = ['SO#', 'Product Description', 'Product Details', 'Qty'];
+    const tableData = [tableHeader.slice()];
+    opts.items.forEach(item => {
+      tableData.push([
+        item.so || '',
+        item.productDescription || '',
+        item.productDetails || '',
+        String(item.qty || '')
+      ]);
+    });
+    const placeholder = body.findText('{{ITEMS_TABLE}}');
+    if (placeholder) {
+      const el = placeholder.getElement();
+      const parent = el.getParent();
+      const index = body.getChildIndex(parent);
+      body.insertTable(index, tableData);
+      parent.removeFromParent();
+    } else {
+      const existing = qc_findQuotationItemsTable_(body, tableHeader);
+      if (existing) {
+        const index = body.getChildIndex(existing);
+        body.removeChild(existing);
+        body.insertTable(index, tableData);
+      } else {
+        body.appendTable(tableData);
+      }
+    }
+  }
+
+  doc.saveAndClose();
+  return { id: doc.getId(), url: doc.getUrl() };
+}
+
+function qc_escapeForRegex_(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function qc_buildQuotationFilename_(brand, selectedSOs, rootApptId) {
+  const label = selectedSOs && selectedSOs.length ? selectedSOs[0] : (rootApptId || '');
+  return [brand || 'Brand', label || 'Row', 'Quotation'].filter(Boolean).join(' – ');
+}
+
+function qc_findQuotationItemsTable_(body, headerRow) {
+  const childCount = body.getNumChildren();
+  for (let i = 0; i < childCount; i++) {
+    const child = body.getChild(i);
+    if (child.getType && child.getType() === DocumentApp.ElementType.TABLE) {
+      const table = child.asTable();
+      if (table.getNumRows() === 0) continue;
+      const firstRow = table.getRow(0);
+      if (firstRow.getNumCells() < headerRow.length) continue;
+      let matches = true;
+      for (let c = 0; c < headerRow.length; c++) {
+        const text = firstRow.getCell(c).getText();
+        if (String(text || '').trim() !== String(headerRow[c] || '').trim()) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) return table;
+    }
+  }
+  return null;
+}
+
+function qc_parseMoney_(value) {
+  if (value === '' || value == null) return '';
+  const n = parseFloat(String(value).replace(/[^0-9.\-]/g, ''));
+  return isFinite(n) ? n : '';
+}

--- a/Quotation_Create_v1.gs
+++ b/Quotation_Create_v1.gs
@@ -2,7 +2,7 @@
  * Create Quotation flow — dialog + document writer
  */
 
-const QC_MASTER_TAB_NAME = '00_Master Appointments';
+const QC_MASTER_TAB_NAME = '00_Master Wholesale';
 
 const QC_SO_ALIASES = ['SO#', 'SO', 'SO Number'];
 const QC_CUSTOMER_NAME_ALIASES = ['Customer Name', 'Customer', 'Client Name'];

--- a/dlg_create_quotation_v1.html
+++ b/dlg_create_quotation_v1.html
@@ -26,6 +26,8 @@
       padding: 18px 22px 70px;
       display: grid;
       gap: 16px;
+      max-width: 1180px;
+      margin: 0 auto;
     }
     .header {
       display: flex;
@@ -49,10 +51,18 @@
     .grid {
       display: grid;
       gap: 16px;
-      grid-template-columns: 280px 1fr 260px;
+      grid-template-columns: minmax(260px, 320px) minmax(480px, 1fr);
+      align-items: start;
+    }
+    .detail-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: minmax(520px, 2.25fr) minmax(220px, 1fr);
+      align-items: start;
     }
     @media (max-width: 1180px) {
       .grid { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+      .detail-grid { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
     }
     .card {
       background: #fff;
@@ -171,6 +181,9 @@
       color: #b91c1c;
     }
     .mini-btn.danger:hover { background: #fecaca; }
+    .table-wrap {
+      overflow-x: auto;
+    }
     .hint {
       font-size: 12px;
       color: #6b7280;
@@ -279,47 +292,49 @@
         </div>
       </section>
 
-      <section class="card" id="colItems">
-        <div class="header" style="margin:0; align-items:center;">
-          <h3 style="margin:0;">Line Items</h3>
-          <button type="button" class="mini-btn" onclick="addCustomRow()">+ Add Row</button>
-        </div>
-        <div class="hint">SO column is locked for selected orders. Custom rows allow blank SOs.</div>
-        <div class="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th style="width:120px;">SO#</th>
-                <th>Product Description</th>
-                <th>Product Details</th>
-                <th style="width:60px;">Qty</th>
-                <th style="width:40px;"></th>
-              </tr>
-            </thead>
-            <tbody id="itemRows"></tbody>
-          </table>
-        </div>
-      </section>
+      <div class="detail-grid">
+        <section class="card" id="colItems">
+          <div class="header" style="margin:0; align-items:center;">
+            <h3 style="margin:0;">Line Items</h3>
+            <button type="button" class="mini-btn" onclick="addCustomRow()">+ Add Row</button>
+          </div>
+          <div class="hint">SO column is locked for selected orders. Custom rows allow blank SOs.</div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th style="width:120px;">SO#</th>
+                  <th>Product Description</th>
+                  <th>Product Details</th>
+                  <th style="width:60px;">Qty</th>
+                  <th style="width:40px;"></th>
+                </tr>
+              </thead>
+              <tbody id="itemRows"></tbody>
+            </table>
+          </div>
+        </section>
 
-      <section class="card" id="colPricing">
-        <h3>Pricing</h3>
-        <div class="hint">Enter currency values. Formatting is applied automatically.</div>
-        <div class="pricing-grid">
-          <div class="field">
-            <label>V1 Quotation <span style="color:#ef4444;">*</span></label>
-            <input id="priceV1" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('v1', this.value)" onblur="onPriceBlur('v1')">
+        <section class="card" id="colPricing">
+          <h3>Pricing</h3>
+          <div class="hint">Enter currency values. Formatting is applied automatically.</div>
+          <div class="pricing-grid">
+            <div class="field">
+              <label>V1 Quotation <span style="color:#ef4444;">*</span></label>
+              <input id="priceV1" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('v1', this.value)" onblur="onPriceBlur('v1')">
+            </div>
+            <div class="field">
+              <label>V2 Quotation</label>
+              <input id="priceV2" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('v2', this.value)" onblur="onPriceBlur('v2')">
+            </div>
+            <div class="field">
+              <label>Approved Price</label>
+              <input id="priceApproved" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('approved', this.value)" onblur="onPriceBlur('approved')">
+            </div>
           </div>
-          <div class="field">
-            <label>V2 Quotation</label>
-            <input id="priceV2" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('v2', this.value)" onblur="onPriceBlur('v2')">
-          </div>
-          <div class="field">
-            <label>Approved Price</label>
-            <input id="priceApproved" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('approved', this.value)" onblur="onPriceBlur('approved')">
-          </div>
-        </div>
-        <div class="hint" id="currencyHint"></div>
-      </section>
+          <div class="hint" id="currencyHint"></div>
+        </section>
+      </div>
     </div>
 
     <div class="actions">

--- a/dlg_create_quotation_v1.html
+++ b/dlg_create_quotation_v1.html
@@ -1,0 +1,686 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <meta charset="utf-8">
+  <style>
+    :root {
+      font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Roboto", sans-serif;
+      color: #1f2937;
+    }
+    body {
+      margin: 0;
+      background: #f9fafb;
+    }
+    h2 {
+      margin: 0 0 12px;
+      font-size: 20px;
+      color: #111827;
+    }
+    h3 {
+      margin: 0 0 8px;
+      font-size: 15px;
+      color: #1f2937;
+    }
+    .wrap {
+      padding: 18px 22px 70px;
+      display: grid;
+      gap: 16px;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+    .header .link a {
+      color: #2563eb;
+      text-decoration: none;
+      font-size: 13px;
+    }
+    .error-box {
+      display: none;
+      padding: 12px;
+      border-radius: 8px;
+      background: #fee2e2;
+      color: #b91c1c;
+      font-size: 13px;
+    }
+    .grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: 280px 1fr 260px;
+    }
+    @media (max-width: 1180px) {
+      .grid { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+    }
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      padding: 16px;
+      box-shadow: 0 12px 30px rgba(15,23,42,0.08);
+      display: grid;
+      gap: 12px;
+    }
+    .field {
+      display: grid;
+      gap: 4px;
+      font-size: 13px;
+    }
+    .field label {
+      font-weight: 600;
+      color: #1f2937;
+    }
+    .readonly {
+      background: #f3f4f6;
+      border-radius: 8px;
+      padding: 8px 10px;
+      min-height: 32px;
+      display: flex;
+      align-items: center;
+      color: #374151;
+    }
+    input[type="text"], input[type="number"], textarea {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid #d1d5db;
+      font-size: 13px;
+      font-family: inherit;
+      transition: border-color .15s ease;
+    }
+    textarea {
+      min-height: 72px;
+      resize: vertical;
+    }
+    input:focus, textarea:focus {
+      border-color: #2563eb;
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(37,99,235,0.12);
+    }
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      max-height: 180px;
+      overflow-y: auto;
+      padding: 4px 0;
+    }
+    .chip {
+      padding: 6px 10px;
+      border-radius: 16px;
+      border: 1px solid #d1d5db;
+      font-size: 12px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+      background: #fff;
+      color: #1f2937;
+      transition: background .15s ease, border-color .15s ease;
+    }
+    .chip.selected {
+      background: #e0e7ff;
+      border-color: #4338ca;
+      color: #312e81;
+      font-weight: 600;
+    }
+    .chip .meta {
+      font-size: 11px;
+      color: #6b7280;
+    }
+    .chip.selected .meta {
+      color: #4338ca;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    thead th {
+      text-align: left;
+      padding: 6px 8px;
+      background: #f3f4f6;
+      border-bottom: 1px solid #e5e7eb;
+      font-weight: 600;
+      color: #374151;
+    }
+    tbody td {
+      padding: 6px 8px;
+      border-bottom: 1px solid #e5e7eb;
+      vertical-align: top;
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody td.actions {
+      width: 36px;
+      text-align: right;
+    }
+    .mini-btn {
+      background: #f3f4f6;
+      border: none;
+      border-radius: 8px;
+      padding: 6px 10px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: background .15s ease;
+    }
+    .mini-btn:hover { background: #e5e7eb; }
+    .mini-btn.danger {
+      background: #fee2e2;
+      color: #b91c1c;
+    }
+    .mini-btn.danger:hover { background: #fecaca; }
+    .hint {
+      font-size: 12px;
+      color: #6b7280;
+    }
+    .pricing-grid {
+      display: grid;
+      gap: 10px;
+    }
+    .currency-input {
+      text-align: right;
+    }
+    .actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+      position: sticky;
+      bottom: 0;
+      padding: 12px 0 0;
+      background: linear-gradient(180deg, rgba(249,250,251,0) 0%, rgba(249,250,251,0.9) 40%, rgba(249,250,251,1) 100%);
+    }
+    button {
+      border-radius: 999px;
+      padding: 10px 18px;
+      border: none;
+      font-size: 13px;
+      cursor: pointer;
+      font-weight: 600;
+      transition: transform .15s ease, box-shadow .15s ease;
+    }
+    button.primary {
+      background: linear-gradient(135deg, #4f46e5, #2563eb);
+      color: #fff;
+      box-shadow: 0 8px 20px rgba(79,70,229,0.35);
+    }
+    button.secondary { background: #e5e7eb; color: #1f2937; }
+    button:disabled {
+      opacity: .6;
+      cursor: wait;
+      box-shadow: none;
+    }
+    .toast {
+      position: fixed;
+      left: 50%;
+      bottom: 24px;
+      transform: translateX(-50%) translateY(20px);
+      background: #111827;
+      color: #f9fafb;
+      padding: 10px 16px;
+      border-radius: 999px;
+      font-size: 13px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .2s ease, transform .2s ease;
+      box-shadow: 0 12px 30px rgba(15,23,42,0.3);
+      z-index: 50;
+    }
+    .toast.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="header">
+      <div>
+        <h2>Create Quotation</h2>
+        <div class="hint">Prefill pulled from 00_Master Appointments. Update fields before generating.</div>
+      </div>
+      <div id="linkWrap" class="link"></div>
+    </div>
+
+    <div id="errorBox" class="error-box"></div>
+
+    <div class="grid">
+      <section class="card" id="colContext">
+        <div class="field">
+          <label>Customer</label>
+          <div class="readonly" id="ctxCustomer">—</div>
+        </div>
+        <div class="field">
+          <label>Email</label>
+          <div class="readonly" id="ctxEmail">—</div>
+        </div>
+        <div class="field">
+          <label>Phone</label>
+          <div class="readonly" id="ctxPhone">—</div>
+        </div>
+        <div class="field">
+          <label>Brand</label>
+          <div class="readonly" id="ctxBrand">—</div>
+        </div>
+        <div class="field">
+          <label>RootApptID</label>
+          <div class="readonly" id="ctxRoot">—</div>
+        </div>
+        <div class="field">
+          <label>Known SOs for this customer</label>
+          <input type="text" id="soSearch" placeholder="Search by SO or brand…" oninput="filterChips(this.value)">
+          <div id="chipList" class="chips"></div>
+          <div class="hint">Select one or more SOs to include. Each adds a line item.</div>
+        </div>
+      </section>
+
+      <section class="card" id="colItems">
+        <div class="header" style="margin:0; align-items:center;">
+          <h3 style="margin:0;">Line Items</h3>
+          <button type="button" class="mini-btn" onclick="addCustomRow()">+ Add Row</button>
+        </div>
+        <div class="hint">SO column is locked for selected orders. Custom rows allow blank SOs.</div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th style="width:120px;">SO#</th>
+                <th>Product Description</th>
+                <th>Product Details</th>
+                <th style="width:60px;">Qty</th>
+                <th style="width:40px;"></th>
+              </tr>
+            </thead>
+            <tbody id="itemRows"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card" id="colPricing">
+        <h3>Pricing</h3>
+        <div class="hint">Enter currency values. Formatting is applied automatically.</div>
+        <div class="pricing-grid">
+          <div class="field">
+            <label>V1 Quotation <span style="color:#ef4444;">*</span></label>
+            <input id="priceV1" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('v1', this.value)" onblur="onPriceBlur('v1')">
+          </div>
+          <div class="field">
+            <label>V2 Quotation</label>
+            <input id="priceV2" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('v2', this.value)" onblur="onPriceBlur('v2')">
+          </div>
+          <div class="field">
+            <label>Approved Price</label>
+            <input id="priceApproved" class="currency-input" type="text" placeholder="$0.00" oninput="onPriceInput('approved', this.value)" onblur="onPriceBlur('approved')">
+          </div>
+        </div>
+        <div class="hint" id="currencyHint"></div>
+      </section>
+    </div>
+
+    <div class="actions">
+      <button type="button" class="secondary" onclick="google.script.host.close()">Cancel</button>
+      <button type="button" id="btnSaveOnly" class="secondary" onclick="submitQuotation(true)">Save Only (no doc)</button>
+      <button type="button" id="btnGenerate" class="primary" onclick="submitQuotation(false)">Generate &amp; Save Quotation</button>
+    </div>
+  </div>
+
+  <div id="toast" class="toast"></div>
+
+  <script>
+    const state = {
+      context: null,
+      items: [],
+      knownSOs: [],
+      selectedKeys: new Set(),
+      pricing: { v1: '', v2: '', approved: '' },
+      pricingInputs: { v1: '', v2: '', approved: '' },
+      chipFilter: '',
+      busy: false,
+      links: {}
+    };
+
+    function init() {
+      toggleBusy(true);
+      google.script.run.withSuccessHandler(onInit).withFailureHandler(err => {
+        toggleBusy(false);
+        showError(err && err.message ? err.message : 'Failed to load context.');
+      }).qc_init();
+    }
+
+    function onInit(payload) {
+      toggleBusy(false);
+      if (!payload || !payload.context) {
+        showError('Unable to load active row context.');
+        return;
+      }
+      state.context = payload.context;
+      state.links = payload.links || {};
+      state.knownSOs = Array.isArray(payload.knownSOs) ? payload.knownSOs : [];
+      renderContext(payload.context);
+      renderLink();
+      if (payload.ui && payload.ui.currencyHint) {
+        document.getElementById('currencyHint').textContent = payload.ui.currencyHint;
+      }
+
+      const snapshot = payload.productSnapshot || {};
+      const baseItem = {
+        id: makeId(),
+        key: null,
+        so: snapshot.so || '',
+        productDescription: snapshot.productDescription || '',
+        productDetails: snapshot.productDetails || '',
+        qty: snapshot.quantity || 1,
+        locked: Boolean(snapshot.so)
+      };
+
+      if (snapshot.so) {
+        const match = state.knownSOs.find(entry => entry.so === snapshot.so);
+        if (match) {
+          state.selectedKeys.add(match.key);
+          baseItem.key = match.key;
+          baseItem.locked = true;
+          baseItem.productDescription = baseItem.productDescription || match.productDescription || '';
+          baseItem.productDetails = baseItem.productDetails || match.productDetails || '';
+          baseItem.qty = match.quantity || baseItem.qty || 1;
+        }
+      }
+
+      state.items = [baseItem];
+      renderChips();
+      renderItems();
+      initPricing(payload.money || {});
+      hideError();
+    }
+
+    function renderContext(ctx) {
+      document.getElementById('ctxCustomer').textContent = ctx.customerName || '—';
+      document.getElementById('ctxEmail').textContent = ctx.emailLower || '—';
+      document.getElementById('ctxPhone').textContent = ctx.phoneNorm || '—';
+      document.getElementById('ctxBrand').textContent = ctx.brand || '—';
+      document.getElementById('ctxRoot').textContent = ctx.RootApptID || '—';
+    }
+
+    function renderLink() {
+      const wrap = document.getElementById('linkWrap');
+      wrap.innerHTML = '';
+      const link = state.links && state.links.quotationUrl && state.links.quotationUrl.url;
+      if (link) {
+        const a = document.createElement('a');
+        a.href = link;
+        a.textContent = 'Open existing quotation';
+        a.target = '_blank';
+        wrap.appendChild(a);
+      }
+    }
+
+    function renderChips() {
+      const host = document.getElementById('chipList');
+      host.innerHTML = '';
+      const filter = state.chipFilter.trim().toLowerCase();
+      state.knownSOs.forEach(entry => {
+        if (filter) {
+          const hay = (entry.label + ' ' + (entry.productDescription || '')).toLowerCase();
+          if (!hay.includes(filter)) return;
+        }
+        const el = document.createElement('div');
+        el.className = 'chip' + (state.selectedKeys.has(entry.key) ? ' selected' : '');
+        el.setAttribute('data-key', entry.key);
+        el.onclick = () => toggleChip(entry.key);
+        const main = document.createElement('div');
+        main.textContent = entry.label || entry.so;
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        meta.textContent = entry.productDescription || '';
+        el.appendChild(main);
+        if (entry.productDescription) el.appendChild(meta);
+        host.appendChild(el);
+      });
+    }
+
+    function renderItems() {
+      const tbody = document.getElementById('itemRows');
+      tbody.innerHTML = '';
+      state.items.forEach((item, idx) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>
+            <input type="text" value="${escapeHtml(item.so || '')}" ${item.locked ? 'readonly' : ''}
+              oninput="onItemSoChange(${idx}, this.value)" placeholder="SO…">
+          </td>
+          <td>
+            <textarea oninput="onItemDescriptionChange(${idx}, this.value)">${escapeHtml(item.productDescription || '')}</textarea>
+          </td>
+          <td>
+            <textarea oninput="onItemDetailsChange(${idx}, this.value)">${escapeHtml(item.productDetails || '')}</textarea>
+          </td>
+          <td>
+            <input type="number" min="1" step="1" value="${Number(item.qty) || 1}" oninput="onItemQtyChange(${idx}, this.value)">
+          </td>
+          <td class="actions">
+            ${item.locked ? '' : `<button type="button" class="mini-btn danger" onclick="removeItem(${idx})">×</button>`}
+          </td>`;
+        tbody.appendChild(tr);
+      });
+    }
+
+    function initPricing(money) {
+      const map = {
+        v1: money['V1 Quotation'] || {},
+        v2: money['V2 Quotation'] || {},
+        approved: money['Approved Price'] || {}
+      };
+      ['v1', 'v2', 'approved'].forEach(key => {
+        const entry = map[key];
+        const number = entry && entry.number !== '' ? Number(entry.number) : '';
+        state.pricing[key] = isFinite(number) ? number : '';
+        state.pricingInputs[key] = entry && entry.display ? entry.display : (isFinite(number) ? formatCurrency(number) : '');
+        const el = document.getElementById(priceInputId(key));
+        if (el) el.value = state.pricingInputs[key] || '';
+      });
+    }
+
+    function priceInputId(key) {
+      return key === 'v1' ? 'priceV1' : key === 'v2' ? 'priceV2' : 'priceApproved';
+    }
+
+    function toggleChip(key) {
+      const entry = state.knownSOs.find(e => e.key === key);
+      if (!entry) return;
+      if (state.selectedKeys.has(key)) {
+        state.selectedKeys.delete(key);
+        state.items = state.items.filter(item => item.key !== key);
+        if (!state.items.length) {
+          state.items.push({ id: makeId(), key: null, so: '', productDescription: '', productDetails: '', qty: 1, locked: false });
+        }
+      } else {
+        state.selectedKeys.add(key);
+        const existing = state.items.find(item => item.key === key);
+        if (!existing) {
+          state.items.push({
+            id: makeId(),
+            key,
+            so: entry.so,
+            productDescription: entry.productDescription || '',
+            productDetails: entry.productDetails || '',
+            qty: entry.quantity || 1,
+            locked: true
+          });
+        }
+      }
+      renderChips();
+      renderItems();
+    }
+
+    function addCustomRow() {
+      state.items.push({ id: makeId(), key: null, so: '', productDescription: '', productDetails: '', qty: 1, locked: false });
+      renderItems();
+    }
+
+    function removeItem(idx) {
+      state.items.splice(idx, 1);
+      if (!state.items.length) {
+        state.items.push({ id: makeId(), key: null, so: '', productDescription: '', productDetails: '', qty: 1, locked: false });
+      }
+      renderItems();
+    }
+
+    function onItemSoChange(idx, value) {
+      const item = state.items[idx];
+      if (!item || item.locked) return;
+      item.so = value;
+    }
+
+    function onItemDescriptionChange(idx, value) {
+      const item = state.items[idx];
+      if (!item) return;
+      item.productDescription = value;
+    }
+
+    function onItemDetailsChange(idx, value) {
+      const item = state.items[idx];
+      if (!item) return;
+      item.productDetails = value;
+    }
+
+    function onItemQtyChange(idx, value) {
+      const item = state.items[idx];
+      if (!item) return;
+      const num = Math.max(1, Math.floor(Number(value || 0)) || 1);
+      item.qty = num;
+      renderItems();
+    }
+
+    function onPriceInput(key, value) {
+      state.pricingInputs[key] = value;
+      const parsed = parseCurrency(value);
+      state.pricing[key] = parsed === '' ? '' : parsed;
+    }
+
+    function onPriceBlur(key) {
+      const value = state.pricing[key];
+      const el = document.getElementById(priceInputId(key));
+      if (!el) return;
+      el.value = value === '' ? '' : formatCurrency(value);
+      state.pricingInputs[key] = el.value;
+    }
+
+    function filterChips(value) {
+      state.chipFilter = value || '';
+      renderChips();
+    }
+
+    function validateBeforeSubmit() {
+      if (!state.items.length) {
+        showToast('Add at least one line item.');
+        return false;
+      }
+      const v1 = state.pricing.v1;
+      if (v1 === '' || !isFinite(v1) || v1 < 0) {
+        showToast('Enter a valid V1 Quotation amount.');
+        return false;
+      }
+      const badQty = state.items.find(item => !item.qty || !isFinite(item.qty) || item.qty < 1);
+      if (badQty) {
+        showToast('Each line item must have Qty ≥ 1.');
+        return false;
+      }
+      return true;
+    }
+
+    function submitQuotation(saveOnly) {
+      if (state.busy) return;
+      if (!validateBeforeSubmit()) return;
+      toggleBusy(true);
+      const payload = {
+        context: state.context,
+        items: state.items.map(item => ({
+          so: item.so || '',
+          productDescription: item.productDescription || '',
+          productDetails: item.productDetails || '',
+          qty: item.qty || 1
+        })),
+        pricing: {
+          v1: state.pricing.v1,
+          v2: state.pricing.v2,
+          approved: state.pricing.approved
+        },
+        saveOnly: !!saveOnly
+      };
+      google.script.run.withSuccessHandler(res => {
+        toggleBusy(false);
+        if (res && res.ok) {
+          showToast(saveOnly ? 'Values saved.' : 'Quotation saved.');
+          if (res.url) {
+            state.links.quotationUrl = { url: res.url };
+            renderLink();
+          }
+        } else {
+          showToast('Save completed with no response.');
+        }
+      }).withFailureHandler(err => {
+        toggleBusy(false);
+        showToast(err && err.message ? err.message : 'Failed to save.');
+      }).qc_submit(payload);
+    }
+
+    function toggleBusy(on) {
+      state.busy = !!on;
+      document.getElementById('btnGenerate').disabled = !!on;
+      document.getElementById('btnSaveOnly').disabled = !!on;
+    }
+
+    function showError(msg) {
+      const box = document.getElementById('errorBox');
+      box.textContent = msg || 'An error occurred.';
+      box.style.display = 'block';
+    }
+
+    function hideError() {
+      const box = document.getElementById('errorBox');
+      box.style.display = 'none';
+    }
+
+    let toastTimer = null;
+    function showToast(msg) {
+      const el = document.getElementById('toast');
+      el.textContent = msg;
+      el.classList.add('show');
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(() => {
+        el.classList.remove('show');
+      }, 2800);
+    }
+
+    function parseCurrency(value) {
+      if (value === '' || value == null) return '';
+      const num = parseFloat(String(value).replace(/[^0-9.\-]/g, ''));
+      return isFinite(num) ? num : '';
+    }
+
+    function formatCurrency(value) {
+      const n = Number(value);
+      if (!isFinite(n)) return '';
+      const sign = n < 0 ? '-' : '';
+      const abs = Math.abs(n);
+      const parts = abs.toFixed(2).split('.');
+      parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+      return sign + '$' + parts[0] + '.' + parts[1];
+    }
+
+    function makeId() {
+      return 'id-' + Math.random().toString(36).slice(2, 10);
+    }
+
+    function escapeHtml(str) {
+      return String(str || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/dlg_create_quotation_v1.html
+++ b/dlg_create_quotation_v1.html
@@ -238,7 +238,7 @@
     <div class="header">
       <div>
         <h2>Create Quotation</h2>
-        <div class="hint">Prefill pulled from 00_Master Wholesale. Update fields before generating.</div>
+        <div class="hint">Prefill pulled from the wholesale orders tab. Update fields before generating.</div>
       </div>
       <div id="linkWrap" class="link"></div>
     </div>
@@ -248,8 +248,20 @@
     <div class="grid">
       <section class="card" id="colContext">
         <div class="field">
-          <label>Customer</label>
+          <label>Business Name</label>
           <div class="readonly" id="ctxCustomer">—</div>
+        </div>
+        <div class="field">
+          <label>Customer ID</label>
+          <div class="readonly" id="ctxCustomerId">—</div>
+        </div>
+        <div class="field">
+          <label>Active SO</label>
+          <div class="readonly" id="ctxSO">—</div>
+        </div>
+        <div class="field">
+          <label>Primary Contact</label>
+          <div class="readonly" id="ctxContact">—</div>
         </div>
         <div class="field">
           <label>Email</label>
@@ -260,16 +272,8 @@
           <div class="readonly" id="ctxPhone">—</div>
         </div>
         <div class="field">
-          <label>Brand</label>
-          <div class="readonly" id="ctxBrand">—</div>
-        </div>
-        <div class="field">
-          <label>RootApptID</label>
-          <div class="readonly" id="ctxRoot">—</div>
-        </div>
-        <div class="field">
           <label>Known SOs for this customer</label>
-          <input type="text" id="soSearch" placeholder="Search by SO or brand…" oninput="filterChips(this.value)">
+          <input type="text" id="soSearch" placeholder="Search by SO or description…" oninput="filterChips(this.value)">
           <div id="chipList" class="chips"></div>
           <div class="hint">Select one or more SOs to include. Each adds a line item.</div>
         </div>
@@ -394,11 +398,18 @@
     }
 
     function renderContext(ctx) {
-      document.getElementById('ctxCustomer').textContent = ctx.customerName || '—';
-      document.getElementById('ctxEmail').textContent = ctx.emailLower || '—';
-      document.getElementById('ctxPhone').textContent = ctx.phoneNorm || '—';
-      document.getElementById('ctxBrand').textContent = ctx.brand || '—';
-      document.getElementById('ctxRoot').textContent = ctx.RootApptID || '—';
+      const set = (id, value) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const text = String(value || '').trim();
+        el.textContent = text || '—';
+      };
+      set('ctxCustomer', ctx.businessName || ctx.customerName || '');
+      set('ctxCustomerId', ctx.customerId || '');
+      set('ctxSO', ctx.SO || '');
+      set('ctxContact', ctx.contactName || '');
+      set('ctxEmail', ctx.emailDisplay || ctx.emailLower || '');
+      set('ctxPhone', ctx.phoneDisplay || ctx.phoneNorm || '');
     }
 
     function renderLink() {
@@ -420,7 +431,7 @@
       const filter = state.chipFilter.trim().toLowerCase();
       state.knownSOs.forEach(entry => {
         if (filter) {
-          const hay = (entry.label + ' ' + (entry.productDescription || '')).toLowerCase();
+          const hay = (entry.label + ' ' + (entry.meta || '') + ' ' + (entry.productDescription || '')).toLowerCase();
           if (!hay.includes(filter)) return;
         }
         const el = document.createElement('div');
@@ -431,9 +442,12 @@
         main.textContent = entry.label || entry.so;
         const meta = document.createElement('div');
         meta.className = 'meta';
-        meta.textContent = entry.productDescription || '';
+        const metaText = entry.meta || entry.productDescription || '';
         el.appendChild(main);
-        if (entry.productDescription) el.appendChild(meta);
+        if (metaText) {
+          meta.textContent = metaText;
+          el.appendChild(meta);
+        }
         host.appendChild(el);
       });
     }

--- a/dlg_create_quotation_v1.html
+++ b/dlg_create_quotation_v1.html
@@ -238,7 +238,7 @@
     <div class="header">
       <div>
         <h2>Create Quotation</h2>
-        <div class="hint">Prefill pulled from 00_Master Appointments. Update fields before generating.</div>
+        <div class="hint">Prefill pulled from 00_Master Wholesale. Update fields before generating.</div>
       </div>
       <div id="linkWrap" class="link"></div>
     </div>

--- a/menu.js
+++ b/menu.js
@@ -8,6 +8,11 @@ function onOpen(){
     .addSeparator()
     .addItem('Record Payment (wholesale)…', 'openWholesaleRecordPayment')
     .addItem('Payment Summary (selected SO)…', 'openWholesalePaymentSummary')
+    .addSubMenu(
+      SpreadsheetApp.getUi()
+        .createMenu('\ud83d\udccf Update Quotation')
+        .addItem('Create Quotation…', 'qc_openCreateQuotation')
+    )
     .addSeparator()
     .addItem('Refresh Config Cache', 'wh_refreshCaches')
     .addToUi();


### PR DESCRIPTION
## Summary
- add Quotation_Create_v1.gs with dialog init, submission, document generation, and sheet writeback helpers for the new Create Quotation flow
- add dlg_create_quotation_v1.html implementing the responsive modal UI with multi-SO chips, line items grid, and pricing inputs
- expose the Create Quotation dialog from the Apps Script menu under the Update Quotation submenu

## Testing
- no automated tests run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d36c49c254832997736f551a0c3b00