### PR TITLE
Improve client status prefill with extended order context

### DIFF
--- a/dlg_wh_status_update.html
+++ b/dlg_wh_status_update.html
@@ -170,8 +170,18 @@
       const title = payload.soDisplay || (payload.row ? `Row ${payload.row}` : 'Selected Order');
       $('orderTitle').textContent = title;
       const details = [];
-      if (payload.customerName) details.push(payload.customerName);
-      if (payload.product) details.push(payload.product);
+      if (payload.soNumber) details.push(`SO#: ${payload.soNumber}`);
+      if (payload.customerId) details.push(`Customer ID: ${payload.customerId}`);
+      if (payload.businessName) {
+        details.push(payload.businessName);
+      } else if (payload.customerName) {
+        details.push(payload.customerName);
+      }
+      if (payload.productDescription) {
+        details.push(payload.productDescription);
+      } else if (payload.product) {
+        details.push(payload.product);
+      }
       $('orderDetails').textContent = details.join(' • ');
 
       const opts = (BOOT && BOOT.options) || {};


### PR DESCRIPTION
## Summary
- read master sheet rows in a single batch when building the client status prefill payload
- include customer ID, business name, SO number, and product description in the returned payload
- surface the expanded context in the client status dialog and saved update summary

## Testing
- not run (Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68d41270c1088329944316e7cbbb94b7