### PR TITLE
Improve payment summary grouping and warnings

### DIFF
--- a/dlg_wh_summary.html
+++ b/dlg_wh_summary.html
@@ -42,6 +42,9 @@
     table.docs tbody tr.overdue td a { color:#b91c1c; }
     .group-warnings { margin-top:12px; background:#fffbeb; border:1px solid #fcd34d; border-radius:8px; padding:12px; color:#92400e; font-size:12px; }
     .group-warnings ul { margin:6px 0 0 18px; padding:0; }
+    .fallback-note { background:#eef2ff; border:1px solid #c7d2fe; border-radius:8px; padding:14px; color:#312e81; font-size:12px; margin-bottom:12px; }
+    .fallback-note strong { display:block; font-size:14px; margin-bottom:6px; }
+    .filters { margin-top:8px; color:#4b5563; }
     .empty { padding:24px; text-align:center; color:#6b7280; font-style:italic; }
     a { color:#2563eb; text-decoration:none; }
     a:hover { text-decoration:underline; }
@@ -100,21 +103,31 @@ function refresh(){
   });
 }
 function asArray(value){
+  if (!value) return [];
   if (Array.isArray(value)) return value;
-  if (!value || typeof value !== 'object') return [];
-  return Object.values(value).filter(v => v !== null && v !== undefined);
+  if (typeof value === 'object') {
+    if (typeof value.length === 'number') {
+      const arr = [];
+      for (let i = 0; i < value.length; i++) {
+        if (Object.prototype.hasOwnProperty.call(value, i)) {
+          arr.push(value[i]);
+        }
+      }
+      if (arr.length) return arr.filter(v => v !== null && v !== undefined);
+    }
+    const keys = Object.keys(value);
+    if (!keys.length) return [];
+    const numericKeys = keys.filter(k => /^\d+$/.test(k)).sort((a,b)=>Number(a)-Number(b));
+    const orderedKeys = numericKeys.length ? numericKeys : keys;
+    return orderedKeys.map(k => value[k]).filter(v => v !== null && v !== undefined);
+  }
+  return [];
 }
 
 function render(res){
   console.debug('[ADM_DEBUG] summary ->', res);
   const groups = asArray(res && res.groups);
-  if (!res || !groups.length) {
-    $('#out').classList.remove('hint');
-    $('#out').innerHTML = `<div class="card empty">No documents found for the selected scope.</div>`;
-    return;
-  }
-
-  const totals = res.totals || {};
+  const totals = res && res.totals || {};
   const totalsHtml = `
     <div class="card">
       <div class="totals">
@@ -126,12 +139,72 @@ function render(res){
       </div>
     </div>`;
 
-  const warnings = asArray(res.warnings);
+  const warnings = asArray(res && res.warnings);
   const warningHtml = warnings.length ? `
     <div class="warnings">
       <strong>Warnings &amp; Alerts</strong>
       <ul>${warnings.map(w => `<li>${safe(w)}</li>`).join('')}</ul>
     </div>` : '';
+
+  const meta = res && res.meta || {};
+  const filters = meta && meta.filters || {};
+  const docsFallback = asArray(res && res.docs);
+
+  if (!res || !groups.length) {
+    $('#out').classList.remove('hint');
+
+    if (docsFallback.length) {
+      const filterSummary = `Scope: ${safe(filters.scope || '') || '—'} · SO: ${safe(filters.soNumber || '') || '—'} · Customer: ${safe(filters.customerId || '') || '—'} · Group: ${safe(filters.invoiceGroupId || '') || '—'}`;
+      const fallbackRows = docsFallback.map(doc => {
+        return `
+          <tr>
+            <td>${safe(doc.displayDate || '')}</td>
+            <td>${safe(doc.groupLabel || '')}</td>
+            <td>${safe(doc.docLabel || doc.docType || '')}</td>
+            <td>${safe(doc.docNumber || '')}</td>
+            <td>${safe(doc.docStatus || '')}</td>
+            <td>${safe(doc.dueDateDisplay || '')}</td>
+            <td class="numeric">${safe(formatCurrency(doc.amount))}</td>
+            <td>${safe(doc.method || '')}</td>
+            <td>${doc.pdfUrl ? `<a href="${safe(doc.pdfUrl)}" target="_blank">PDF</a>` : ''}</td>
+          </tr>`;
+      }).join('');
+
+      $('#out').innerHTML = `${warningHtml}${totalsHtml}
+        <div class="card">
+          <div class="group-body">
+            <div class="fallback-note">
+              <strong>Ledger matches found</strong>
+              <div>Showing ${docsFallback.length} document${docsFallback.length === 1 ? '' : 's'} directly because the grouped summary was empty.</div>
+              <div class="filters">${filterSummary}</div>
+            </div>
+            <table class="docs">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Group</th>
+                  <th>Document</th>
+                  <th>Number</th>
+                  <th>Status</th>
+                  <th>Due</th>
+                  <th class="numeric">Amount</th>
+                  <th>Method</th>
+                  <th>Links</th>
+                </tr>
+              </thead>
+              <tbody>${fallbackRows}</tbody>
+            </table>
+          </div>
+        </div>`;
+      return;
+    }
+
+    const filterText = (filters.scope || filters.soNumber || filters.customerId || filters.invoiceGroupId)
+      ? `<div class="hint">Checked scope ${safe(filters.scope || 'SO')} for SO ${safe(filters.soNumber || '—')} · Customer ${safe(filters.customerId || '—')} · Group ${safe(filters.invoiceGroupId || '—')}.</div>`
+      : '';
+    $('#out').innerHTML = `<div class="card empty">No documents found for the selected scope.</div>${filterText}`;
+    return;
+  }
 
   const groupsHtml = groups.map(group => {
     const docs = asArray(group && group.docs);

--- a/dlg_wh_summary.html
+++ b/dlg_wh_summary.html
@@ -4,14 +4,47 @@
   <base target="_top">
   <meta charset="utf-8">
   <style>
-    body { font: 13px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Arial; margin:0; padding:16px; }
-    h2 { margin: 0 0 12px; }
-    .row { display:flex; gap:12px; align-items:center; margin-bottom:10px; }
-    input[type=text], select { padding:8px; }
-    table { width:100%; border-collapse:collapse; margin-top:6px; }
-    th, td { border:1px solid #ddd; padding:6px; text-align:left; }
-    th { background:#fafafa; }
-    .hint { color:#777; }
+    body { font: 13px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Arial; margin:0; padding:16px; background:#f3f4f6; color:#111827; }
+    h2 { margin: 0 0 16px; font-size:20px; font-weight:700; }
+    .row { display:flex; flex-wrap:wrap; gap:12px; align-items:flex-end; margin-bottom:16px; }
+    label { display:block; font-weight:600; color:#374151; margin-bottom:4px; font-size:12px; letter-spacing:0.01em; text-transform:uppercase; }
+    input[type=text], select { padding:8px 10px; border:1px solid #d1d5db; border-radius:6px; min-width:140px; font-size:13px; }
+    input[type=text]:focus, select:focus { outline:none; border-color:#2563eb; box-shadow:0 0 0 3px rgba(37,99,235,0.15); }
+    button { padding:9px 16px; border:none; border-radius:6px; background:#2563eb; color:#fff; font-weight:600; cursor:pointer; }
+    button:hover { background:#1d4ed8; }
+    #out { display:flex; flex-direction:column; gap:16px; }
+    .hint { color:#6b7280; font-style:italic; }
+    .card { background:#fff; border-radius:10px; border:1px solid #e5e7eb; box-shadow:0 8px 16px -12px rgba(15,23,42,0.45); }
+    .totals { display:flex; flex-wrap:wrap; gap:12px; padding:16px; }
+    .totals span { font-weight:600; }
+    .totals .label { font-weight:500; color:#6b7280; margin-right:4px; }
+    .totals .balance.negative { color:#b91c1c; }
+    .totals .balance.positive { color:#047857; }
+    .warnings { background:#fffbeb; border:1px solid #fcd34d; border-radius:10px; padding:16px; color:#92400e; }
+    .warnings strong { display:block; font-size:14px; margin-bottom:8px; }
+    .warnings ul { margin:0; padding-left:18px; }
+    details.group { background:#fff; border-radius:10px; border:1px solid #e5e7eb; overflow:hidden; }
+    details.group + details.group { margin-top:8px; }
+    summary { list-style:none; cursor:pointer; padding:14px 16px; display:flex; flex-wrap:wrap; gap:12px; align-items:center; background:#f9fafb; font-weight:600; }
+    summary::-webkit-details-marker { display:none; }
+    .group-title { font-size:15px; font-weight:700; color:#111827; }
+    .group-meta { color:#4b5563; font-weight:500; }
+    .spacer { flex:1 1 auto; }
+    .badge { display:inline-flex; align-items:center; padding:2px 8px; border-radius:999px; font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.04em; }
+    .badge.overdue { background:#fee2e2; color:#b91c1c; }
+    .group-body { padding:0 16px 16px; }
+    table.docs { width:100%; border-collapse:collapse; margin-top:12px; }
+    table.docs th { text-align:left; font-weight:600; color:#374151; font-size:12px; text-transform:uppercase; padding-bottom:8px; border-bottom:1px solid #e5e7eb; }
+    table.docs td { padding:8px 0; border-bottom:1px solid #f3f4f6; vertical-align:top; }
+    table.docs tr:last-child td { border-bottom:none; }
+    table.docs td.numeric { text-align:right; font-variant-numeric:tabular-nums; }
+    table.docs tbody tr.overdue td { background:#fef2f2; color:#b91c1c; }
+    table.docs tbody tr.overdue td a { color:#b91c1c; }
+    .group-warnings { margin-top:12px; background:#fffbeb; border:1px solid #fcd34d; border-radius:8px; padding:12px; color:#92400e; font-size:12px; }
+    .group-warnings ul { margin:6px 0 0 18px; padding:0; }
+    .empty { padding:24px; text-align:center; color:#6b7280; font-style:italic; }
+    a { color:#2563eb; text-decoration:none; }
+    a:hover { text-decoration:underline; }
   </style>
 </head>
 <body>
@@ -36,6 +69,28 @@
 <script>
 function $(s){ return document.querySelector(s); }
 
+const ENTITY_MAP = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;'
+};
+ENTITY_MAP['"'] = '&quot;';
+ENTITY_MAP["'"] = '&#39;';
+
+function safe(value){
+  if (value === null || value === undefined) return '';
+  return String(value).replace(/[&<>"']/g, c => ENTITY_MAP[c] || c);
+}
+
+function formatCurrency(value){
+  if (typeof value !== 'number' || !isFinite(value)) return '';
+  return new Intl.NumberFormat('en-US', { style:'currency', currency:'USD' }).format(value);
+}
+
+function formatList(items){
+  return items && items.length ? items.join(', ') : '—';
+}
+
 function refresh(){
   google.script.run.withSuccessHandler(render).wh_getSummary({
     scope: $('#scope').value,
@@ -46,24 +101,88 @@ function refresh(){
 }
 function render(res){
   console.debug('[ADM_DEBUG] summary ->', res);
-  if (!res || !res.items) { $('#out').textContent='No data.'; return; }
-  const rows = res.items.map(it=>`
-    <tr>
-      <td>${it.DOC_DATE || it.PaymentDateTime || ''}</td>
-      <td>${it.DocType||''} ${it.DocFlavor||''}</td>
-      <td>${it.DocNumber||''}</td>
-      <td>${it.InvoiceGroupID||''}</td>
-      <td>${it.SOsCSV||''}</td>
-      <td>${it.AmountGross||''}</td>
-      <td>${it.Method||''}</td>
-      <td>${it.DocStatus||''}</td>
-      <td>${it.PDF_URL?`<a href="${it.PDF_URL}" target="_blank">PDF</a>`:''}</td>
-    </tr>`).join('');
-  $('#out').innerHTML = `
-    <table>
-      <thead><tr><th>Date</th><th>Doc</th><th>Doc #</th><th>Group</th><th>SOs</th><th>Amount</th><th>Method</th><th>Status</th><th></th></tr></thead>
-      <tbody>${rows || '<tr><td colspan="9" class="hint">No rows.</td></tr>'}</tbody>
-    </table>`;
+  if (!res || !Array.isArray(res.groups) || !res.groups.length) {
+    $('#out').classList.remove('hint');
+    $('#out').innerHTML = `<div class="card empty">No documents found for the selected scope.</div>`;
+    return;
+  }
+
+  const totals = res.totals || {};
+  const totalsHtml = `
+    <div class="card">
+      <div class="totals">
+        <span><span class="label">Invoiced:</span>${formatCurrency(totals.invoiced)}</span>
+        <span><span class="label">Receipts:</span>${formatCurrency(totals.receipts)}</span>
+        <span><span class="label">Credits Applied:</span>${formatCurrency(totals.creditsApplied)}</span>
+        <span><span class="label">Credits Issued:</span>${formatCurrency(totals.creditsIssued)}</span>
+        <span><span class="label">Outstanding:</span><span class="balance ${totals.balance > 0 ? 'negative' : 'positive'}">${formatCurrency(totals.balance)}</span></span>
+      </div>
+    </div>`;
+
+  const warningHtml = (res.warnings && res.warnings.length) ? `
+    <div class="warnings">
+      <strong>Warnings &amp; Alerts</strong>
+      <ul>${res.warnings.map(w => `<li>${safe(w)}</li>`).join('')}</ul>
+    </div>` : '';
+
+  const groupsHtml = res.groups.map(group => {
+    const docRows = group.docs && group.docs.length ? group.docs.map(doc => {
+      const rowClass = doc.isOverdue ? ' class="overdue"' : '';
+      return `
+        <tr${rowClass}>
+          <td>${safe(doc.displayDate || '')}</td>
+          <td>${safe(doc.docLabel || doc.docType || '')}</td>
+          <td>${safe(doc.docNumber || '')}</td>
+          <td>${safe(doc.docStatus || '')}</td>
+          <td>${safe(doc.dueDateDisplay || '')}</td>
+          <td class="numeric">${safe(formatCurrency(doc.amount))}</td>
+          <td>${safe(doc.method || '')}</td>
+          <td>${doc.pdfUrl ? `<a href="${safe(doc.pdfUrl)}" target="_blank">PDF</a>` : ''}</td>
+        </tr>`;
+    }).join('') : `<tr><td colspan="8" class="hint">No documents in this group.</td></tr>`;
+
+    const groupWarnings = group.warnings && group.warnings.length
+      ? `<div class="group-warnings"><strong>Group alerts</strong><ul>${group.warnings.map(w => `<li>${safe(w)}</li>`).join('')}</ul></div>`
+      : '';
+
+    const badges = [];
+    if (group.hasOverdue) badges.push('<span class="badge overdue">Overdue</span>');
+
+    return `
+      <details class="group" ${group.hasOverdue ? 'open' : ''}>
+        <summary>
+          <span class="group-title">${safe(group.label || 'Invoice Group')}</span>
+          <span class="group-meta">SOs: ${safe(formatList(group.soNumbers || []))}</span>
+          <span class="group-meta">Due Next: ${safe(group.nextDueDateDisplay || '—')}</span>
+          <span class="spacer"></span>
+          <span class="group-meta">Invoiced: ${safe(formatCurrency(group.totals?.invoiced))}</span>
+          <span class="group-meta">Received: ${safe(formatCurrency((group.totals?.receipts || 0) + (group.totals?.creditApplied || 0)))}</span>
+          <span class="group-meta">Balance: ${safe(formatCurrency(group.totals?.balance))}</span>
+          ${badges.join('')}
+        </summary>
+        <div class="group-body">
+          ${groupWarnings}
+          <table class="docs">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Document</th>
+                <th>Number</th>
+                <th>Status</th>
+                <th>Due</th>
+                <th class="numeric">Amount</th>
+                <th>Method</th>
+                <th>Links</th>
+              </tr>
+            </thead>
+            <tbody>${docRows}</tbody>
+          </table>
+        </div>
+      </details>`;
+  }).join('');
+
+  $('#out').classList.remove('hint');
+  $('#out').innerHTML = `${warningHtml}${totalsHtml}${groupsHtml}`;
 }
 google.script.run.withSuccessHandler(({ctx})=>{
   if (ctx && ctx.soNumber) $('#so').value = ctx.soNumber;

--- a/dlg_wh_summary.html
+++ b/dlg_wh_summary.html
@@ -99,9 +99,16 @@ function refresh(){
     invoiceGroupId: $('#gid').value.trim()
   });
 }
+function asArray(value){
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== 'object') return [];
+  return Object.values(value).filter(v => v !== null && v !== undefined);
+}
+
 function render(res){
   console.debug('[ADM_DEBUG] summary ->', res);
-  if (!res || !Array.isArray(res.groups) || !res.groups.length) {
+  const groups = asArray(res && res.groups);
+  if (!res || !groups.length) {
     $('#out').classList.remove('hint');
     $('#out').innerHTML = `<div class="card empty">No documents found for the selected scope.</div>`;
     return;
@@ -119,14 +126,16 @@ function render(res){
       </div>
     </div>`;
 
-  const warningHtml = (res.warnings && res.warnings.length) ? `
+  const warnings = asArray(res.warnings);
+  const warningHtml = warnings.length ? `
     <div class="warnings">
       <strong>Warnings &amp; Alerts</strong>
-      <ul>${res.warnings.map(w => `<li>${safe(w)}</li>`).join('')}</ul>
+      <ul>${warnings.map(w => `<li>${safe(w)}</li>`).join('')}</ul>
     </div>` : '';
 
-  const groupsHtml = res.groups.map(group => {
-    const docRows = group.docs && group.docs.length ? group.docs.map(doc => {
+  const groupsHtml = groups.map(group => {
+    const docs = asArray(group && group.docs);
+    const docRows = docs.length ? docs.map(doc => {
       const rowClass = doc.isOverdue ? ' class="overdue"' : '';
       return `
         <tr${rowClass}>
@@ -141,17 +150,18 @@ function render(res){
         </tr>`;
     }).join('') : `<tr><td colspan="8" class="hint">No documents in this group.</td></tr>`;
 
-    const groupWarnings = group.warnings && group.warnings.length
-      ? `<div class="group-warnings"><strong>Group alerts</strong><ul>${group.warnings.map(w => `<li>${safe(w)}</li>`).join('')}</ul></div>`
+    const groupWarningsList = asArray(group && group.warnings);
+    const groupWarnings = groupWarningsList.length
+      ? `<div class="group-warnings"><strong>Group alerts</strong><ul>${groupWarningsList.map(w => `<li>${safe(w)}</li>`).join('')}</ul></div>`
       : '';
 
     const badges = [];
-    if (group.hasOverdue) badges.push('<span class="badge overdue">Overdue</span>');
+    if (group && group.hasOverdue) badges.push('<span class="badge overdue">Overdue</span>');
 
     return `
-      <details class="group" ${group.hasOverdue ? 'open' : ''}>
+      <details class="group" ${(group && group.hasOverdue) ? 'open' : ''}>
         <summary>
-          <span class="group-title">${safe(group.label || 'Invoice Group')}</span>
+          <span class="group-title">${safe(group && group.label || 'Invoice Group')}</span>
           <span class="group-meta">SOs: ${safe(formatList(group.soNumbers || []))}</span>
           <span class="group-meta">Due Next: ${safe(group.nextDueDateDisplay || '—')}</span>
           <span class="spacer"></span>

--- a/wholesale_payments.js
+++ b/wholesale_payments.js
@@ -5,7 +5,7 @@
 const SP = PropertiesService.getScriptProperties();
 
 // ============================= CONFIG =============================
-const WH_LEDGER_TAB_NAME         = SP.getProperty('WH_LEDGER_TAB_NAME') || '400_payments ledger';
+const WH_LEDGER_TAB_NAME         = SP.getProperty('WH_LEDGER_TAB_NAME') || '400_Payments Ledger';
 const WH_CRM_TAB_NAME            = SP.getProperty('WH_CRM_TAB_NAME') || '01_CRM';
 const WH_DEFAULT_SHIP_PER_ORDER  = num_(SP.getProperty('WH_DEFAULT_SHIP_PER_ORDER'), 50);
 const WH_SHIP_THRESHOLD_SUBTOTAL = num_(SP.getProperty('WH_SHIP_THRESHOLD_SUBTOTAL'), 2000);
@@ -674,37 +674,262 @@ function wh_markSuperseded_(docNumber, action){
 
 // ============================= SUMMARY =============================
 function wh_getSummary(params){
-  const scope = String(params.scope||'SO').toUpperCase();
-  const sh = ensureLedger_(); const lr = sh.getLastRow(), lc = sh.getLastColumn();
-  if (lr < 2) return { scope, items:[], totals:{} };
+  params = params || {};
+  let scope = String(params.scope||'').trim().toUpperCase();
+  let soNumber = String(params.soNumber||'').trim();
+  let customerId = String(params.customerId||'').trim();
+  let invoiceGroupId = String(params.invoiceGroupId||'').trim();
+
+  if (!soNumber || !customerId) {
+    const ctx = readActiveContext_();
+    if (!soNumber && ctx.soNumber) soNumber = String(ctx.soNumber||'').trim();
+    if (!customerId && ctx.customerId) customerId = String(ctx.customerId||'').trim();
+  }
+
+  if (!scope) {
+    if (invoiceGroupId) {
+      scope = 'GROUP';
+    } else if (soNumber) {
+      scope = 'SO';
+    } else if (customerId) {
+      scope = 'CUSTOMER';
+    } else {
+      scope = 'SO';
+    }
+  }
+
+  if (scope === 'SO' && !soNumber && customerId) {
+    scope = 'CUSTOMER';
+  }
+
+  if (scope === 'CUSTOMER' && !customerId && soNumber) {
+    scope = 'SO';
+  }
+
+  const sh = ensureLedger_();
+  const lr = sh.getLastRow(), lc = sh.getLastColumn();
+  if (lr < 2) {
+    return { scope, items:[], totals:{}, groups:[], warnings:[] };
+  }
 
   const hdr = sh.getRange(1,1,1,lc).getDisplayValues()[0].map(s=>String(s||'').trim());
   const H = headerMap_(hdr);
   const vals = sh.getRange(2,1,lr-1,lc).getValues();
 
   const items = [];
+  const tz = Session.getScriptTimeZone() || 'UTC';
+  const now = new Date();
+  const nowMs = now.getTime();
+  const groupsByKey = new Map();
+  const activeInvoicesBySO = new Map();
+  const globalTotals = {
+    invoiced: 0,
+    receipts: 0,
+    creditsIssued: 0,
+    creditsApplied: 0
+  };
+
   for (let i=0;i<vals.length;i++){
-    const r = vals[i]; const o={}; Object.keys(H).forEach(k=>o[k]=r[H[k]-1]);
-    const match = scope==='SO'       ? (String(o.SOsCSV||'').split(',').map(s=>s.trim()).includes(String(params.soNumber||'').trim()))
-                : scope==='CUSTOMER' ? (String(o.CustomerID||'').trim() === String(params.customerId||'').trim())
-                : scope==='GROUP'    ? (String(o.InvoiceGroupID||'').trim() === String(params.invoiceGroupId||'').trim())
-                : false;
-    if (match) items.push(o);
-  }
-  const receipts = items.filter(it => String(it.DocType||'').toUpperCase()==='RECEIPT')
-                        .reduce((s,it)=> s + num_(it.AmountGross,0),0);
-  const credits  = items.filter(it => String(it.DocType||'').toUpperCase()==='CREDIT')
-                        .reduce((s,it)=> s + num_(it.AmountGross,0),0);
-  const applied  = items.filter(it => String(it.DocType||'').toUpperCase()==='CREDIT-APPLIED')
-                        .reduce((s,it)=> s + num_(it.AmountGross,0),0);
-  return {
-    scope, items,
-    totals: {
-      receipts: round2_(receipts),
-      creditsIssued: round2_(credits),
-      creditsApplied: round2_(applied),
-      creditUnappliedEstimate: round2_(credits - applied)
+    const r = vals[i];
+    const raw = {};
+    Object.keys(H).forEach(k=>raw[k]=r[H[k]-1]);
+
+    const soQuery = soNumber;
+    const match = scope==='SO'
+      ? (soQuery ? parseSummarySOList_(raw).some(so => soEq_(so, soQuery)) : false)
+      : scope==='CUSTOMER'
+        ? (String(raw.CustomerID||'').trim() === customerId)
+        : scope==='GROUP'
+          ? (String(raw.InvoiceGroupID||'').trim() === invoiceGroupId)
+          : false;
+    if (!match) continue;
+
+    items.push(raw);
+
+    const docTypeRaw = String(raw.DocType||'');
+    const docTypeUpper = docTypeRaw.toUpperCase();
+    const docFlavor = String(raw.DocFlavor||'');
+    const docStatus = String(raw.DocStatus||'');
+    const amount = round2_(num_(raw.AmountGross,0));
+
+    const docDate = coerceDate_(raw.DOC_DATE || raw.PaymentDateTime || raw.SubmittedAt);
+    const paymentDate = coerceDate_(raw.PaymentDateTime);
+    const dueDate = coerceDate_(raw.DueDate);
+
+    const docDateMs = docDate ? docDate.getTime() : (paymentDate ? paymentDate.getTime() : null);
+    const dueDateMs = dueDate ? dueDate.getTime() : null;
+
+    const soNumbers = parseSummarySOList_(raw);
+
+    const docOut = {
+      docType: docTypeRaw,
+      docFlavor,
+      docLabel: buildSummaryDocLabel_(docTypeRaw, docFlavor),
+      docNumber: String(raw.DocNumber||'').trim(),
+      docStatus,
+      displayDate: formatDateForSummary_(docDate || paymentDate || raw.SubmittedAt, tz),
+      docDateDisplay: formatDateForSummary_(docDate, tz),
+      paymentDateDisplay: formatDateForSummary_(paymentDate, tz),
+      dueDateDisplay: formatDateForSummary_(dueDate, tz),
+      docDateIso: docDate ? docDate.toISOString() : '',
+      dueDateIso: dueDate ? dueDate.toISOString() : '',
+      amount,
+      method: String(raw.Method||'').trim(),
+      pdfUrl: String(raw.PDF_URL||'').trim(),
+      invoiceGroupId: String(raw.InvoiceGroupID||'').trim(),
+      soNumbers,
+      isInvoice: isInvoiceDoc_(docTypeUpper),
+      isReceipt: isReceiptDoc_(docTypeUpper),
+      isCredit: docTypeUpper === 'CREDIT',
+      isCreditApplied: docTypeUpper === 'CREDIT-APPLIED',
+      isActiveInvoice: false,
+      dueDateMs,
+      activityMs: docDateMs,
+      notes: String(raw.Notes||'').trim()
+    };
+
+    docOut.isActiveInvoice = docOut.isInvoice && isActiveInvoiceStatus_(docStatus);
+
+    const groupKey = docOut.invoiceGroupId || '__' + (docOut.docNumber || raw.PaymentID || ('ROW'+(i+2)));
+    if (!groupsByKey.has(groupKey)) {
+      groupsByKey.set(groupKey, {
+        key: groupKey,
+        invoiceGroupId: docOut.invoiceGroupId,
+        docs: [],
+        soNumbers: new Set(),
+        totals: { invoiced: 0, receipts: 0, creditsIssued: 0, creditApplied: 0 },
+        dueDates: [],
+        latestActivityMs: docDateMs || 0,
+        warnings: []
+      });
     }
+    const group = groupsByKey.get(groupKey);
+    group.docs.push(docOut);
+    if (docOut.activityMs && docOut.activityMs > (group.latestActivityMs||0)) {
+      group.latestActivityMs = docOut.activityMs;
+    }
+    soNumbers.forEach(so => { if (so) group.soNumbers.add(so); });
+
+    if (docOut.isInvoice) {
+      group.totals.invoiced = round2_(group.totals.invoiced + amount);
+      globalTotals.invoiced = round2_(globalTotals.invoiced + amount);
+      if (dueDate) group.dueDates.push(dueDate);
+    } else if (docOut.isReceipt) {
+      group.totals.receipts = round2_(group.totals.receipts + amount);
+      globalTotals.receipts = round2_(globalTotals.receipts + amount);
+    } else if (docOut.isCreditApplied) {
+      group.totals.creditApplied = round2_(group.totals.creditApplied + amount);
+      globalTotals.creditsApplied = round2_(globalTotals.creditsApplied + amount);
+    } else if (docOut.isCredit) {
+      group.totals.creditsIssued = round2_(group.totals.creditsIssued + amount);
+      globalTotals.creditsIssued = round2_(globalTotals.creditsIssued + amount);
+    }
+
+    if (docOut.isActiveInvoice) {
+      soNumbers.forEach(so => {
+        if (!so) return;
+        if (!activeInvoicesBySO.has(so)) activeInvoicesBySO.set(so, []);
+        activeInvoicesBySO.get(so).push({
+          docNumber: docOut.docNumber,
+          invoiceGroupId: docOut.invoiceGroupId,
+          status: docStatus
+        });
+      });
+    }
+  }
+
+  const groups = [];
+  const generalWarnings = [];
+
+  groupsByKey.forEach(group => {
+    const soNumbers = Array.from(group.soNumbers).filter(Boolean).sort();
+    const balance = round2_(group.totals.invoiced - (group.totals.receipts + group.totals.creditApplied));
+    const dueDateMsList = group.dueDates.map(d=>d.getTime()).sort((a,b)=>a-b);
+    const overdueDocs = group.docs.filter(doc => doc.isInvoice && doc.isActiveInvoice && doc.dueDateMs && doc.dueDateMs < nowMs);
+    const hasOverdue = balance > 0 && overdueDocs.length > 0;
+    const oldestOverdueMs = overdueDocs.length ? Math.min.apply(null, overdueDocs.map(doc=>doc.dueDateMs)) : null;
+    const oldestOverdueDisplay = oldestOverdueMs ? formatDateForSummary_(new Date(oldestOverdueMs), tz) : '';
+
+    if (hasOverdue && oldestOverdueDisplay) {
+      group.warnings.push(`Outstanding balance is past due (oldest due ${oldestOverdueDisplay}).`);
+    }
+
+    group.docs.forEach(doc => {
+      doc.isOverdue = hasOverdue && doc.isInvoice && doc.isActiveInvoice && doc.dueDateMs && doc.dueDateMs < nowMs;
+    });
+
+    const groupLabel = group.invoiceGroupId || (soNumbers.length ? `SO ${soNumbers.join(', ')}` : 'Ungrouped');
+
+    groups.push({
+      invoiceGroupId: group.invoiceGroupId,
+      label: groupLabel,
+      soNumbers,
+      totals: {
+        invoiced: round2_(group.totals.invoiced),
+        receipts: round2_(group.totals.receipts),
+        creditApplied: round2_(group.totals.creditApplied),
+        creditsIssued: round2_(group.totals.creditsIssued),
+        balance
+      },
+      hasOverdue,
+      oldestOverdueDisplay,
+      nextDueDateDisplay: dueDateMsList.length ? formatDateForSummary_(new Date(dueDateMsList[0]), tz) : '',
+      latestActivityMs: group.latestActivityMs || 0,
+      warnings: group.warnings.slice(),
+      docs: group.docs.map(doc => ({
+        docType: doc.docType,
+        docFlavor: doc.docFlavor,
+        docLabel: doc.docLabel,
+        docNumber: doc.docNumber,
+        docStatus: doc.docStatus,
+        displayDate: doc.displayDate,
+        docDateDisplay: doc.docDateDisplay,
+        paymentDateDisplay: doc.paymentDateDisplay,
+        dueDateDisplay: doc.dueDateDisplay,
+        docDateIso: doc.docDateIso,
+        dueDateIso: doc.dueDateIso,
+        amount: doc.amount,
+        method: doc.method,
+        pdfUrl: doc.pdfUrl,
+        isInvoice: doc.isInvoice,
+        isReceipt: doc.isReceipt,
+        isCredit: doc.isCredit,
+        isCreditApplied: doc.isCreditApplied,
+        isOverdue: doc.isOverdue,
+        isActiveInvoice: doc.isActiveInvoice,
+        soNumbers: doc.soNumbers,
+        amountFormatted: formatCurrency_(doc.amount)
+      }))
+    });
+
+    if (hasOverdue) {
+      const balanceText = formatCurrency_(balance);
+      generalWarnings.push(`Invoice group ${groupLabel} has an outstanding balance of ${balanceText} that is past due${oldestOverdueDisplay ? ' (oldest due '+oldestOverdueDisplay+')' : ''}.`);
+    }
+  });
+
+  groups.sort((a,b)=> (b.latestActivityMs||0) - (a.latestActivityMs||0));
+
+  activeInvoicesBySO.forEach((docs, so) => {
+    if (docs.length <= 1) return;
+    const docList = docs.map(d => d.docNumber || d.invoiceGroupId || 'invoice').join(', ');
+    generalWarnings.push(`SO ${so} has multiple active invoices (${docList}).`);
+  });
+
+  const totals = {
+    invoiced: round2_(globalTotals.invoiced),
+    receipts: round2_(globalTotals.receipts),
+    creditsIssued: round2_(globalTotals.creditsIssued),
+    creditsApplied: round2_(globalTotals.creditsApplied),
+    balance: round2_(globalTotals.invoiced - (globalTotals.receipts + globalTotals.creditsApplied))
+  };
+
+  return {
+    scope,
+    items,
+    totals,
+    groups,
+    warnings: dedupeSummaryWarnings_(generalWarnings)
   };
 }
 
@@ -727,6 +952,77 @@ function wh_applyCreditNow(payload){
   setIf_(row,H,'SubmittedAt', new Date());
   sh.appendRow(row);
   return { ok:true };
+}
+
+function parseSummarySOList_(row){
+  const out = [];
+  const seen = new Set();
+  const add = so => {
+    const val = String(so||'').trim();
+    if (!val || seen.has(val)) return;
+    seen.add(val);
+    out.push(val);
+  };
+  add(row.PrimarySO);
+  String(row.SOsCSV||'').split(',').forEach(part => {
+    const cleaned = String(part||'').split(':')[0].trim();
+    add(cleaned);
+  });
+  return out;
+}
+
+function buildSummaryDocLabel_(docType, docFlavor){
+  const parts = [String(docType||'').trim(), String(docFlavor||'').trim()].filter(Boolean);
+  return parts.join(' — ');
+}
+
+function isInvoiceDoc_(docTypeUpper){
+  return String(docTypeUpper||'').toUpperCase().indexOf('INVOICE') >= 0;
+}
+
+function isReceiptDoc_(docTypeUpper){
+  return String(docTypeUpper||'').toUpperCase().indexOf('RECEIPT') >= 0;
+}
+
+function isActiveInvoiceStatus_(status){
+  const s = String(status||'').toUpperCase();
+  if (!s) return true;
+  const inactiveFlags = ['VOID','VOIDED','SUPERSEDED','SUPERSEDE','CANCELLED','CANCELED','SUPERCEDED'];
+  return !inactiveFlags.some(flag => s.indexOf(flag) >= 0);
+}
+
+function coerceDate_(value){
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : value;
+  }
+  if (value === null || value === undefined || value === '') return null;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function formatDateForSummary_(value, tz){
+  const d = coerceDate_(value);
+  if (!d) return '';
+  return Utilities.formatDate(d, tz || Session.getScriptTimeZone() || 'UTC', 'yyyy-MM-dd');
+}
+
+function formatCurrency_(amount){
+  const n = num_(amount, NaN);
+  if (!isFinite(n)) return '';
+  const fixed = round2_(n).toFixed(2);
+  return '$' + fixed.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function dedupeSummaryWarnings_(warnings){
+  const seen = new Set();
+  const out = [];
+  (warnings||[]).forEach(msg => {
+    const text = String(msg||'').trim();
+    if (!text || seen.has(text)) return;
+    seen.add(text);
+    out.push(text);
+  });
+  return out;
 }
 
 function getUnappliedCredit_(customerId){
@@ -1304,7 +1600,18 @@ function hIndex_(hdr){ const H={}; (hdr||[]).forEach((h,i)=>{ const k=String(h||
 function pickH_(H, names){ for (const n of (names||[])) if (H[n]) return H[n]; return 0; }
 function headerMap_(hdrRow){ const m={}; hdrRow.forEach((h,i)=>{ m[String(h||'').trim()] = i+1; }); return m; }
 function setIf_(row,H,key,val){ if (H[key]) row[H[key]-1] = val; }
-function soEq_(a,b){ const sa=String(a||'').trim(), sb=String(b||'').trim(); if (sa===sb) return true; const na=Number(sa.replace(/[^\d.]/g,'')), nb=Number(sb.replace(/[^\d.]/g,'')); return (isFinite(na)&&isFinite(nb)) ? (Math.abs(na-nb)<1e-9) : false; }
+function normalizeSo_(value){
+  const raw = String(value||'').trim().toUpperCase();
+  if (!raw) return '';
+  return raw.replace(/[^A-Z0-9]/g, '');
+}
+
+function soEq_(a,b){
+  const na = normalizeSo_(a);
+  const nb = normalizeSo_(b);
+  if (!na || !nb) return false;
+  return na === nb;
+}
 function num_(v, d){ const n=parseFloat(String(v||'').replace(/[^\d.\-]/g,'')); return isFinite(n)?n:(d||0); }
 function round2_(n){ return Math.round(num_(n,0)*100)/100; }
 function money_(n){ n=num_(n,0); const s=n.toFixed(2); return '$'+s.replace(/\B(?=(\d{3})+(?!\d))/g,','); }


### PR DESCRIPTION
## Summary
- add server-side payment summary aggregation that groups docs by invoice group, tracks balances, and flags overdue or duplicate invoices
- refresh the payment summary dialog UI to display grouped invoices/receipts with expandable detail tables and warning banners
- expose helper utilities for formatting, grouping SOs, and deduplicating warning messages
- normalize SO matching in payment summary lookups so existing invoices and receipts with alternate formatting appear in the results
- allow the payment summary to fall back to the active row's SO or customer and ensure it reads from the 400_Payments Ledger tab by default

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d423c246908329932dfbced89f99ba